### PR TITLE
[feature/14] Generate automatically the single auhtor page

### DIFF
--- a/plugins/author_page.rb
+++ b/plugins/author_page.rb
@@ -1,0 +1,32 @@
+##
+# Bridgetown plugin to generate dynamically each author page.
+#
+class AuthorPage < SiteBuilder
+  def build
+    generator do
+      if site.layouts.key? "author_index"
+        site.data.authors.each_key do |author|
+          site.pages << AuthorPage.new(site, author)
+        end
+      end
+    end
+  end
+
+  # A Page subclass
+  class AuthorPage < Bridgetown::Page
+    def initialize(site, author)
+      @site = site
+      @base = site.source # start in src
+      @dir  = "authors/#{author.downcase.gsub(' ', '-')}" # aka authors/<author>
+      @name = "index.html" # filename
+      process(@name) # saves internal filename and extension information
+
+      # Load in front matter and content from the layout
+      read_yaml("_layouts", "author_index.html")
+
+      # Inject data into the generated page:
+      data["author"] = author
+      data["title"] = "Author @#{author}"
+    end
+  end
+end

--- a/src/_data/authors.yml
+++ b/src/_data/authors.yml
@@ -4,7 +4,6 @@ jveillet:
   handle: jveillet
   description: Jérémie is a french software developer from La Rochelle, France. he is currently working at macompta.fr, and he loves art in every shape and form.
   avatar: https://avatars1.githubusercontent.com/u/5037407?v=3&s=460
-  email: jveillet@users.noreply.github.com
   web:
     handle: demainilpleut.dev
     link: https://www.demainilpleut.dev

--- a/src/_data/site_metadata.yml
+++ b/src/_data/site_metadata.yml
@@ -6,7 +6,6 @@
 
 title: demain·il·pleut
 tagline: Coding & Design for the rainy days
-email: jveillet@hey.com
 description:
 logo: images/logo.png
 canonical_url: https://www.demainilpleut.dev

--- a/src/_layouts/author_index.html
+++ b/src/_layouts/author_index.html
@@ -1,14 +1,12 @@
 ---
 layout: default
-author: jveillet
-permalink: /authors/jveillet
 ---
 
 {% assign author = site.data.authors[page.author] %}
 
 <article class="page page-author">
 
-  <h1>{{author.name}}</h1>
+  <h1>{{ author.name }}</h1>
 
   <div class="page-author-avatar">
     <img src="{{ author.avatar }}" alt="{{ author.handle }}" class="avatar avatar--size">

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -29,7 +29,7 @@
   {% feed_meta %}
   <link media="screen" rel="stylesheet" href="{% webpack_path css %}" />
   {% if bridgetown.environment == 'production' %}
-    {% assign img_url = 'images/' | relative_url %}
+    {% assign img_url = 'images' | relative_url %}
   {% else %}
     {% assign img_url = 'images/dev' | relative_url %}
   {% endif %}
@@ -39,7 +39,7 @@
   <link rel="icon" href="{{ img_url }}/favicon-32.png" sizes="32x32" />
   <link rel="icon" href="{{ img_url }}/favicon-16.png" sizes="16x16" />
   <link rel="icon" href="{{ img_url }}/favicon-128.png" sizes="128x128" />
-  <link rel="manifest" href="assets/manifest.json"">
+  <link rel="manifest" href="{% link assets/manifest.json %}">
   <script>
     if (
           localStorage.getItem('data-theme') == 'dark' ||


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added custom plugin to generate author page based on `src/_data/authors.yml`.
Added layout for author templating.
Removed old authors pages.
Fixed link to manifest files.
Fixed links to favicons when in production mode.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #14 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Easier authors handling by modifying the YML file to generate automatically the needed HTML files. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Maintenance task (Templates, README, dependencies, general config)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
