### PR TITLE
[feature/16] Add breadcrumb navigation on the single authors pages

### DIFF
--- a/frontend/styles/archive.scss
+++ b/frontend/styles/archive.scss
@@ -3,6 +3,12 @@ Name: archive.scss
 Description: Archives section styles
 */
 
+.page-archive {
+  margin-bottom: 1em;
+  padding-left: .8em;
+  padding-right: .8em;
+}
+
 .archives-spacing {
   margin-bottom: 2em;
 }
@@ -19,42 +25,6 @@ Description: Archives section styles
 
 .archives-header {
   margin-bottom: 3em;
-}
-
-.breadcrumb-icon {
-  background: var(--breadcrumb-icon),
-    linear-gradient(transparent, transparent);
-  background-size: auto 1.5em;
-  display: block;
-  padding: .5em 1.5em .5em 1em;
-}
-
-.breadcrumbs {
-  display: flex;
-  flex-flow: row wrap;
-  flex-direction: row;
-  /* This aligns items to the end line on main-axis */
-  align-items: center;
-  justify-content: flex-start;
-}
-
-.archives-breadcrumb {
-  margin-left: 1em;
-}
-
-.breadcrumb-active {
-  margin-left: 1em;
-}
-
-.breadcrumb-item a:link,
-.breadcrumb-item a:visited {
-  text-decoration: none;
-  color: var(--breadcrumb-color);
-}
-
-.breadcrumb-item a:hover {
-  text-decoration: underline;
-  color: var(--breadcrumb-hover-color);
 }
 
 .archives-link a:link,

--- a/frontend/styles/author.scss
+++ b/frontend/styles/author.scss
@@ -5,6 +5,8 @@ Description: Author section styles
 
 .page-author {
   margin-bottom: 1em;
+  padding-left: .8em;
+  padding-right: .8em;
 }
 
 .avatar {

--- a/frontend/styles/breadcrumb.scss
+++ b/frontend/styles/breadcrumb.scss
@@ -1,0 +1,37 @@
+/**
+Name: breadcrumb.scss
+Description: Breadcrumb styles.
+*/
+
+.breadcrumbs {
+  display: flex;
+  flex-flow: row wrap;
+  flex-direction: row;
+  /* This aligns items to the end line on main-axis */
+  align-items: center;
+  justify-content: flex-start;
+  margin-top: 1.5em;
+}
+
+.breadcrumb-icon {
+  background: var(--breadcrumb-icon),
+    linear-gradient(transparent, transparent);
+  background-size: auto 1.5em;
+  display: block;
+  padding: .5em 1.5em .5em 1em;
+}
+
+.breadcrumb-item--active {
+  margin-left: .5em;
+}
+
+.breadcrumb-item a:link,
+.breadcrumb-item a:visited {
+  text-decoration: none;
+  color: var(--breadcrumb-color);
+}
+
+.breadcrumb-item a:hover {
+  text-decoration: underline;
+  color: var(--breadcrumb-hover-color);
+}

--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -318,5 +318,6 @@ a, b, strong, dt {
 @import "footer";
 @import "styleguide";
 @import "topbar";
+@import "breadcrumb";
 
 @import "prism.min.css";

--- a/frontend/styles/post.scss
+++ b/frontend/styles/post.scss
@@ -10,7 +10,6 @@ Description: Styles for articles / posts
 }
 
 .page {
-  border-radius: .2em;
   margin-bottom: 1em;
   margin-top: 1em;
   padding: 2em;

--- a/frontend/styles/styleguide.scss
+++ b/frontend/styles/styleguide.scss
@@ -3,6 +3,12 @@ Name: styleguide.scss
 Description: Styleguide specific  styles
 */
 
+.page-styleguide {
+  margin-bottom: 1em;
+  padding-left: .8em;
+  padding-right: .8em;
+}
+
 .patterns {
   margin-top: 1em;
 }

--- a/src/_layouts/author_index.html
+++ b/src/_layouts/author_index.html
@@ -4,31 +4,38 @@ layout: default
 
 {% assign author = site.data.authors[page.author] %}
 
-<article class="page page-author">
-
-  <h1>{{ author.name }}</h1>
-
-  <div class="page-author-avatar">
-    <img src="{{ author.avatar }}" alt="{{ author.handle }}" class="avatar avatar--size">
+<div class="page-author">
+  <div class="breadcrumbs">
+    <div class="breadcrumb-item"><a href="{% link _pages/authors.html %}" class="breadcrumb-icon">Authors</a></div>
+    <div class="breadcrumb-item breadcrumb-item--active">{{ author.name }}</div>
   </div>
 
-  <div class="article-excerpt archives-spacing">{{ author.description }}</div>
+  <div class="page-author">
+    <h1>{{ author.name }}</h1>
 
-  <div class="archives archives-spacing">
-    {% render "author_links" site: site, author: author %}
+    <div class="page-author-avatar">
+      <img src="{{ author.avatar }}" alt="{{ author.handle }}" class="avatar avatar--size">
+    </div>
+
+    <div class="article-excerpt archives-spacing">{{ author.description }}</div>
+
+    <div class="archives archives-spacing">
+      {% render "author_links" site: site, author: author %}
+    </div>
+
+  <div class="archives">
+    <span class="section-title">Articles by {{ author.name }}</span>
+    <ol class="list-unordered" start="1" type="1">
+      {% for post in site.posts %}
+        {% if author.handle == post.author %}
+          <li>
+            <a href="{{ post.url | relative_url }}" class="primary-link">{{ post.title }}</a>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ol>
   </div>
 
-<div class="archives">
-  <span class="section-title">Articles by {{ author.name }}</span>
-  <ol class="list-unordered" start="1" type="1">
-    {% for post in site.posts %}
-      {% if author.handle == post.author %}
-        <li>
-          <a href="{{ post.url | relative_url }}" class="primary-link">{{ post.title }}</a>
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ol>
+  </div>
+
 </div>
-
-</article>

--- a/src/_layouts/category_index.html
+++ b/src/_layouts/category_index.html
@@ -2,13 +2,11 @@
 layout: default
 ---
 
-<div class="page">
+<div class="page-archive">
 
-  <div class="archives-breadcrumb">
-    <div class="breadcrumbs">
-      <div class="breadcrumb-item"><a href="{{ 'archives' | relative_url }}" class="breadcrumb-icon">Archives</a></div>
-      <div class="breadcrumb-item breadcrumb-active">{{ page.title }}</div>
-    </div>
+  <div class="breadcrumbs">
+    <div class="breadcrumb-item"><a href="{{ 'archives' | relative_url }}" class="breadcrumb-icon">Archives</a></div>
+    <div class="breadcrumb-item breadcrumb-item--active">{{ page.title }}</div>
   </div>
 
   <div class="posts">

--- a/src/_layouts/category_month.html
+++ b/src/_layouts/category_month.html
@@ -2,16 +2,14 @@
 layout: default
 ---
 
-<div class="page">
+<div class="page-archive">
 
   {% assign this_year = page.date | date: "%Y" %}
 
-  <div class="archives-breadcrumb">
-    <div class="breadcrumbs">
-      <div class="breadcrumb-item"><a href="{{ 'archives' | relative_url }}" class="breadcrumb-icon">Archives</a></div>
-      <div class="breadcrumb-item"><a href="{{ 'archives/'| append: this_year | relative_url }}" class="breadcrumb-icon">{{ this_year }}</a></div>
-      <div class="breadcrumb-item breadcrumb-active">{{ page.date | date: "%B" }}</div>
-    </div>
+  <div class="breadcrumbs">
+    <div class="breadcrumb-item"><a href="{{ 'archives' | relative_url }}" class="breadcrumb-icon">Archives</a></div>
+    <div class="breadcrumb-item"><a href="{{ 'archives/'| append: this_year | relative_url }}" class="breadcrumb-icon">{{ this_year }}</a></div>
+    <div class="breadcrumb-item breadcrumb-item--active">{{ page.date | date: "%B" }}</div>
   </div>
 
   <div class="posts">

--- a/src/_layouts/category_year.html
+++ b/src/_layouts/category_year.html
@@ -2,15 +2,13 @@
 layout: default
 ---
 
-<div class="page">
+<div class="page-archive">
 
   {% assign this_year = page.date | date: "%Y" %}
 
-  <div class="archives-breadcrumb">
-    <div class="breadcrumbs">
-      <div class="breadcrumb-item"><a href="{{ 'archives/' | relative_url }}" class="breadcrumb-item-link breadcrumb-icon">Archives</a></div>
-      <div class="breadcrumb-item breadcrumb-active">{{ this_year }}</div>
-    </div>
+  <div class="breadcrumbs">
+    <div class="breadcrumb-item"><a href="{{ 'archives/' | relative_url }}" class="breadcrumb-item-link breadcrumb-icon">Archives</a></div>
+    <div class="breadcrumb-item breadcrumb-item--active">{{ this_year }}</div>
   </div>
 
   <div class="articles">

--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -2,11 +2,11 @@
 layout: default
 ---
 
-<article class="page">
+<div class="page">
 
   <h1>{{ page.title }}</h1>
 
   <div class="entry">
     {{ content }}
   </div>
-</article>
+</div>

--- a/src/_pages/archives.html
+++ b/src/_pages/archives.html
@@ -3,51 +3,49 @@ layout: default
 permalink: /archives/
 ---
 
-<article class="article">
+<div class="page-archive">
+  <div class="archives-header">
+    <h1>Archives</h1>
 
-<div class="archives-header">
-  <h1>Archives</h1>
+    <div class="article-excerpt">Welcome to the archives. Here you can find all of the posts made over the
+        years, the most popular stuff, the bad, the ugly and the usefull.</div>
+  </div>
 
-  <div class="article-excerpt">Welcome to the archives. Here you can find all of the posts made over the
-      years, the most popular stuff, the bad, the ugly and the usefull.</div>
-</div>
+  <div class="archives archives-spacing">
+    <span class="section-title">Last 10 Posts</span>
+    <ol class="list-ordered" start="1" type="1">
+      {% for post in site.posts limit:10 offset:0 %}
+      <li class="archives-link">
+        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+      </li>
+      {% endfor %}
+    </ol>
+  </div>
 
-<div class="archives archives-spacing">
-  <span class="section-title">Last 10 Posts</span>
-  <ol class="list-ordered" start="1" type="1">
-    {% for post in site.posts limit:10 offset:0 %}
-    <li class="archives-link">
-      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-    </li>
+  <div class ="archives archives-spacing">
+    <span class="section-title">By Categories</span>
+    <ul class="list-unordered">
+    {% for category in site.categories %}
+      {% assign cat = category | first | downcase | replace: ' ', '-' %}
+      <li class="archives-link"><a href="{{ 'archives/' | append: cat | relative_url }}">{{ category | first }}</a><span class="archives-complement">({{ category | last | size }})</span></li>
     {% endfor %}
-  </ol>
-</div>
+    </ul>
+  </div>
 
-<div class ="archives archives-spacing">
-  <span class="section-title">By Categories</span>
-  <ul class="list-unordered">
-  {% for category in site.categories %}
-    {% assign cat = category | first | downcase | replace: ' ', '-' %}
-    <li class="archives-link"><a href="{{ 'archives/' | append: cat | relative_url }}">{{ category | first }}</a><span class="archives-complement">({{ category | last | size }})</span></li>
-  {% endfor %}
-  </ul>
-</div>
-
-<div class ="archives">
-  <span class="section-title">By month</span>
-  {% assign counter = 0 %}
-  {% for post in site.posts %}
-    {% assign thisyear = post.date | date: "%B %Y" %}
-    {% assign prevyear = post.previous.date | date: "%B %Y" %}
-    {% assign counter = counter | plus: 1 %}
-    {% if thisyear != prevyear %}
-      <span class="archives-link"><a href="{{ 'archives/' | relative_url }}{{ post.date | date:"%Y" }}/{{ post.date | date:"%m" }}">{{ thisyear }}</a><span class="archives-complement">({{ counter }})</span></span>
-      {% if forloop.last == false %}
-        |&nbsp;
+  <div class ="archives">
+    <span class="section-title">By month</span>
+    {% assign counter = 0 %}
+    {% for post in site.posts %}
+      {% assign thisyear = post.date | date: "%B %Y" %}
+      {% assign prevyear = post.previous.date | date: "%B %Y" %}
+      {% assign counter = counter | plus: 1 %}
+      {% if thisyear != prevyear %}
+        <span class="archives-link"><a href="{{ 'archives/' | relative_url }}{{ post.date | date:"%Y" }}/{{ post.date | date:"%m" }}">{{ thisyear }}</a><span class="archives-complement">({{ counter }})</span></span>
+        {% if forloop.last == false %}
+          |&nbsp;
+        {% endif %}
+        {% assign counter = 0 %}
       {% endif %}
-      {% assign counter = 0 %}
-    {% endif %}
-  {% endfor %}
+    {% endfor %}
+  </div>
 </div>
-
-</article>

--- a/src/_pages/authors.html
+++ b/src/_pages/authors.html
@@ -3,7 +3,7 @@ layout: default
 permalink: /authors/
 ---
 
-<article class="page page-author">
+<div class="page-author">
   <h1>Authors</h1>
   <div class="article-excerpt">Here is all the beautifull people that are contributing to this blog.</div>
 
@@ -50,4 +50,4 @@ permalink: /authors/
     </div><!-- End of member -->
     {% endfor %}
   </div><!-- End of members-list -->
-</article>
+</div>

--- a/src/_pages/styleguide.html
+++ b/src/_pages/styleguide.html
@@ -6,7 +6,7 @@ image:
    alt: 'Placeholder image'
 ---
 
-<div class= "page">
+<div class= "page-styleguide">
   <h1>Styleguide</h1>
   <div class="article-excerpt">This is the collection of UI components we are using on the blog,
     completed with code samples.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added breadcrum navigation to authors pages.
Refactor breadcrumb into its own CSS file.
Refactor styling on the author page.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #16 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Starting point to have a dedicated breadcrumb component + consistency on navigation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Maintenance task (Templates, README, dependencies, general config)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
