### PR TITLE
[hotfix/57] Footer is not pushed at the bottom when the page content is small

### DIFF
--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -156,10 +156,7 @@ html {
   line-height: 1.5;
   margin: 0;
   padding: 0;
-  min-height: 100%;
   text-size-adjust: 100%;
-  height: 100%;
-  overflow: hidden;
 }
 
 body {
@@ -167,11 +164,9 @@ body {
   background-color: var(--main-background-color);
   color: var(--main-text-color);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
-  height: 100%;
   margin: 0;
   padding: 0;
-  width: 100%;
-  overflow: scroll;
+  overflow: auto;
   -webkit-overflow-scrolling: touch;
   text-rendering: optimizeSpeed;
 }
@@ -318,6 +313,20 @@ a, b, strong, dt {
   color: var(--post-primary-link-color);
   text-decoration: underline;
 }
+
+/** Push the footer to the bottom **/
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+main {
+  flex: 1;
+}
+
+//***********************************
 
 @import "utilities";
 @import "alert";


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Removed old code to push the footer at the bottom.
Used flexbox to push the footer at the bottom.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #57 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Used newer CSS techniques that simplifies the maintenance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox and Chrome.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/5037407/132202474-1d221a8a-3e97-4be4-992c-04519f38bba7.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Maintenance task (Templates, README, dependencies, general config)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
